### PR TITLE
Code sample and connection string fixes

### DIFF
--- a/modules/devguide/examples/node/src/startusing_commonjs.js
+++ b/modules/devguide/examples/node/src/startusing_commonjs.js
@@ -9,11 +9,7 @@ async function main() {
     // User Input ends here.
 
     const credential = new columnar.Credential(username, password)
-    const cluster = columnar.createInstance(clusterConnStr, credential, {
-        securityOptions: {
-            disableServerCertificateVerification: true, // Should not use this in production
-        },
-    })
+    const cluster = columnar.createInstance(clusterConnStr, credential)
 
     // Execute a streaming query with positional arguments.
     let qs = 'SELECT * FROM `travel-sample`.inventory.airline LIMIT 10;'

--- a/modules/devguide/examples/node/src/startusing_esmodules.js
+++ b/modules/devguide/examples/node/src/startusing_esmodules.js
@@ -9,11 +9,7 @@ async function main() {
     // User Input ends here.
 
     const credential = new Credential(username, password)
-    const cluster = createInstance(clusterConnStr, credential, {
-        securityOptions: {
-            disableServerCertificateVerification: true, // Should not use this in production
-        },
-    })
+    const cluster = createInstance(clusterConnStr, credential)
 
     // Execute a streaming query with positional arguments.
     let qs = "SELECT * FROM `travel-sample`.inventory.airline LIMIT 10;"

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -38,11 +38,7 @@ async function main() {
   // User Input ends here.
 
   const credential = new columnar.Credential(username, password)
-  const cluster = columnar.createInstance(clusterConnStr, credential, {
-    securityOptions: {
-      trustOnlyCertificates: columnar.Certificates.getNonprodCertificates(),
-    },
-  })
+  const cluster = columnar.createInstance(clusterConnStr, credential)
 ----
 
 
@@ -87,7 +83,7 @@ The client fetches the full address list from the first node it is able to conta
 
 .Connection string with two parameters
 ----
-couchbases://cb.<your-endpoint>.cloud.couchbase.com?io.networkResolution=external&timeout.kvTimeout=10s
+couchbases://cb.<your-endpoint>.cloud.couchbase.com?timeout.connect_timeout=75s&timeout.query_timeout=100s
 ----
 
 The full list of recognized parameters is documented in the xref:ref:client-settings.adoc[client settings reference].

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -11,7 +11,7 @@ Settings are changed by adding them to the connection string, as in the followin
 
 .Connection string with two parameters
 ----
-couchbases://cb.<your-endpoint>.cloud.couchbase.com?io.networkResolution=external&timeout.kvTimeout=10s
+couchbases://cb.<your-endpoint>.cloud.couchbase.com?timeout.connect_timeout=75s&timeout.query_timeout=100s
 ----
 
 // TODO add complete listings


### PR DESCRIPTION
Changes:
- Updated code samples to not use use `disableServerCertificateVerification`
- Fixed connection string parameters to use valid options